### PR TITLE
bugfix: ipv6 addresses returned instead of ipv4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,11 @@ $ curl https://raw.githubusercontent.com/jharshman/fwsync/master/install.sh | sh
 ## Usage
 
 ### Authentication
-Communication to the GoogleAPIs requires either setting the environment variable `GOOGLE_APPLICATION_CREDENTIALS` or
-alternatively running `gcloud auth application-default login`. If using the `GOOGLE_APPLICATION_CREDENTIALS` environment
-variable, it must point to the full path to your downloaded service account json.
+The reccomended method of authentication is to run the following command:
 
-For example:
-
-`$ export GOOGLE_APPLICATION_CREDENTIALS=/Users/bob/bobserviceaccount.json`
+```bash
+$ gcloud auth application-default login
+```
 
 ### Init
 After installing, you can invoke the CLI by typing `fwsync` in your terminal.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -49,7 +49,7 @@ func Initialize() *cobra.Command {
 
 				_, ok := ask(fmt.Sprintf("You've selected %s, is that correct? [Y/n]: ", firewalls.Items[i].Name), true, func(val string) bool {
 					switch val {
-					case "Y", "y", "yes":
+					case "Y", "y", "yes", "":
 					case "N", "n", "no":
 						return false
 					default:
@@ -92,7 +92,7 @@ func Initialize() *cobra.Command {
 			// prompt to nuke existing configuration file.
 			ask("Existing configuration file detected. Continue anyway? [Y/n]: ", false, func(val string) bool {
 				switch val {
-				case "Y", "y", "yes":
+				case "Y", "y", "yes", "":
 				case "N", "n", "no":
 					os.Exit(0)
 				default:

--- a/install.sh
+++ b/install.sh
@@ -6,22 +6,33 @@ OS=$(uname -s | tr -d '\n')
 ARCH=$(uname -m | tr -d '\n')
 RELEASE=https://github.com/jharshman/fwsync/releases/download/${VERSION}/fwsync_${OS}_${ARCH}.tar.gz
 
+which wget > /dev/null 2>&1
+if [[ $? != 0 ]]; then
+  echo "FATAL missing wget"
+  exit 1
+fi
+
 # install
 mkdir -p $HOME/.local/bin
-wget $RELEASE
+wget -q $RELEASE
 tar -C $HOME/.local/bin/ --exclude README.md -zxvf fwsync_${OS}_${ARCH}.tar.gz
 chmod +x $HOME/.local/bin/fwsync
 
+rcfile="$HOME/.zshrc"
+if [[ $SHELL == "/bin/bash" ]]; then
+  rcfile="$HOME/.bashrc"
+fi
+
 # update PATH if required.
-if ! grep -q '# ADDED BY FWSYNC' $HOME/.zshrc; then
-  echo "export PATH=\$HOME/.local/bin:\$PATH # ADDED BY FWSYNC" >> $HOME/.zshrc
+if ! grep -q '# ADDED BY FWSYNC' $rcfile; then
+  echo "export PATH=\$HOME/.local/bin:\$PATH # ADDED BY FWSYNC" >> $rcfile
 fi
 
 cat <<EOM
-/////////////
-// FWSYNC has been installed at $HOME/.local/bin/fwsync
-//
-// Your PATH has been updated in .zshrc.
-// Restart your Terminal for the changes to take effect.
-///////////////////////////////////////////////////////////
+********************************************************
+* FWSYNC has been installed at $HOME/.local/bin/fwsync
+*
+* Your PATH has been updated in $rcfile
+* Restart your Terminal for the changes to take effect.
+********************************************************
 EOM

--- a/internal/user/firewall.go
+++ b/internal/user/firewall.go
@@ -82,7 +82,7 @@ func (c *Config) Remove(ip string) {
 func PublicIP() (string, error) {
 	// use https://icanhazip.com/
 	// reliable and owned and operated by cloudflare.
-	res, err := http.Get("https://icanhazip.com")
+	res, err := http.Get("https://ipv4.icanhazip.com")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This change updates the icanhazip url to include the subdomain ipv4 making the full url ipv4.icanhazip.com. This will help to ensure that the returned IP address is always an ipv4 address.

Additionally included in this change is some requested ease-of-use features such as the install script supporting Bash and ensuring that hitting "Enter" on a Y/n prompt defaults to Y.
