### PR TITLE
bugfix: Skip synchronization if IPs are up-to-date.

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -16,6 +16,7 @@ func Update() *cobra.Command {
 
 	// Local variable shared between the closures.
 	var local *user.Config
+	var skipSync bool
 
 	return &cobra.Command{
 		Use:   "update",
@@ -36,6 +37,7 @@ func Update() *cobra.Command {
 			currentIP, _ := user.PublicIP()
 			_, ipExists := cfg.HasIP(currentIP)
 			if ipExists {
+				skipSync = true
 				return nil
 			}
 
@@ -53,6 +55,10 @@ func Update() *cobra.Command {
 			return cfg.Write(f)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
+			if skipSync {
+				fmt.Println("IPs are up-to-date, skipping sync.")
+				return nil
+			}
 			fmt.Println("syncing firewall rule")
 			return synchronize(local)
 		},

--- a/main.go
+++ b/main.go
@@ -34,18 +34,28 @@ connecting from and keeps your development VM firewall rule up to date with that
 	}
 	fmt.Println("Operation complete, no errors.")
 
-	notifyIfUpdateAvailable()
+	err := notifyIfUpdateAvailable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
 }
 
-func notifyIfUpdateAvailable() {
-	cli, _ := ghapi.DefaultRESTClient()
+func notifyIfUpdateAvailable() error {
+	cli, err := ghapi.DefaultRESTClient()
+	if err != nil {
+		return err
+	}
 	latestTag := struct {
 		Tag string `json:"tag_name"`
 	}{}
-	cli.Get("repos/jharshman/fwsync/releases/latest", &latestTag)
+	err = cli.Get("repos/jharshman/fwsync/releases/latest", &latestTag)
+	if err != nil {
+		return err
+	}
 	tag := strings.TrimPrefix(latestTag.Tag, "v")
 	if tag != version {
 		fmt.Printf("\n\033[0;32mA new version (%q) is available for fwsync.\033[0m\n", latestTag.Tag)
 		fmt.Printf("\033[0;32mTo update run:\ncurl https://raw.githubusercontent.com/jharshman/fwsync/master/install.sh | sh\033[0m\n")
 	}
+	return nil
 }


### PR DESCRIPTION
This change fixes a nil pointer in a `PostRunE` function. Sync will be skipped If the newly detected IP address is already present in the configuration file.