### PR TITLE
bugfix: Missing newline for PATH modification

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ fi
 
 # update PATH if required.
 if ! grep -q '# ADDED BY FWSYNC' $rcfile; then
+  echo ""
   echo "export PATH=\$HOME/.local/bin:\$PATH # ADDED BY FWSYNC" >> $rcfile
 fi
 


### PR DESCRIPTION
This PR fixes a small bug that can cause an error in the rc file when the path to fwsync is appeneded. To avoid this a newline is placed before the call to export.