### PR TITLE
install: Add friendly name for fwsync.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ mkdir -p $HOME/.local/bin
 wget -q $RELEASE
 tar -C $HOME/.local/bin/ --exclude README.md -zxvf fwsync_${OS}_${ARCH}.tar.gz
 chmod +x $HOME/.local/bin/fwsync
+ln -sf $HOME/.local/bin/fwsync $HOME/.local/bin/firewall-sync
 
 rcfile="$HOME/.zshrc"
 if [[ $SHELL == "/bin/bash" ]]; then


### PR DESCRIPTION
Add a friendlier name "firewall-sync" which is a symbolic link to the real installed binary. This provides users with a more explicit name to invoke on the command line without breaking functionality for users that already invoke fwsync.