### PR TITLE
Replace the const for project with a settable value

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/jharshman/fwsync)](https://goreportcard.com/report/github.com/jharshman/fwsync)
 
 Provides CLI interface to update your personal Firewall Rules
-associated with your Cloud Development VM.
+associated with your Google Cloud Development VM.
 
 ## Installation
 
@@ -28,7 +28,7 @@ This by default will display some usage information.
 
 To initialize fwsync type `fwsync init`. This will walk you through steps in
 selecting the correct firewall to manage and will write out fwsync's config file
-which will be located at `$HOME/.bitly_firewall`.
+which will be located at `$HOME/.fwsync`.
 
 ### Update
 If your IP updates and you notice  you've lost access to your CloudVM,

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,8 +11,7 @@ import (
 )
 
 const (
-	transactionFile = ".bitly_firewall"
-	project         = "bitly-devvm"
+	transactionFile = ".fwsync"
 )
 
 var (
@@ -25,11 +24,12 @@ var (
 // public IP. Any existing source IPs on the firewall rule will be overwritten.
 func Initialize() *cobra.Command {
 	var local *user.Config
-	return &cobra.Command{
+	var gcpProject string
+	initCmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize fwsync configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			firewalls, err := auth.GoogleCloudAuthorizedClient.Firewalls.List(project).Do()
+			firewalls, err := auth.GoogleCloudAuthorizedClient.Firewalls.List(gcpProject).Do()
 			if err != nil {
 				return err
 			}
@@ -74,6 +74,7 @@ func Initialize() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			cfg.Project = gcpProject
 			local = cfg
 
 			// write file
@@ -107,6 +108,9 @@ func Initialize() *cobra.Command {
 			return synchronize(local)
 		},
 	}
+	initCmd.Flags().StringVar(&gcpProject, "project", "", "GCP Project")
+	initCmd.MarkFlagRequired("project")
+	return initCmd
 }
 
 func ask(prompt string, skipRetry bool, check func(val string) bool) (string, bool) {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -32,7 +32,7 @@ func List() *cobra.Command {
 			localIPs := cfg.SourceIPs
 
 			// get configured fw ips
-			fw, err := auth.GoogleCloudAuthorizedClient.Firewalls.Get(project, cfg.Name).Do()
+			fw, err := auth.GoogleCloudAuthorizedClient.Firewalls.Get(cfg.Project, cfg.Name).Do()
 			if err != nil {
 				return err
 			}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -98,7 +98,7 @@ func synchronize(cfg *user.Config) error {
 	fw := &compute.Firewall{
 		SourceRanges: cfg.SourceIPs,
 	}
-	_, err := auth.GoogleCloudAuthorizedClient.Firewalls.Patch(project, cfg.Name, fw).Do()
+	_, err := auth.GoogleCloudAuthorizedClient.Firewalls.Patch(cfg.Project, cfg.Name, fw).Do()
 	if err != nil {
 		return err
 	}

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,13 @@ wget -q $RELEASE
 tar -C $HOME/.local/bin/ --exclude README.md --exclude LICENSE -zxvf fwsync_${OS}_${ARCH}.tar.gz
 chmod +x $HOME/.local/bin/fwsync
 
+# migrate existing bitly users' transaction file from .bitly_firewall to .fwsync
+if [[ -e $HOME/.bitly_firewall ]]; then
+  echo "project: bitly-devvm" > $HOME/.fwsync
+  cat $HOME/.bitly_firewall >> $HOME/.fwsync
+  rm -f $HOME/.bitly_firewall
+fi
+
 rcfile="$HOME/.zshrc"
 if [[ $SHELL == "/bin/bash" ]]; then
   rcfile="$HOME/.bashrc"

--- a/internal/user/firewall.go
+++ b/internal/user/firewall.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Config struct {
+	Project   string   `yaml:"project,omitempty"`
 	Name      string   `yaml:"name"`
 	SourceIPs []string `yaml:"ips"`
 }


### PR DESCRIPTION
Replace the const for the project with a settable value and store the
value in the transactionFile. The fwsync init command will now require a
--project argument.

Ex:
```
$ fwsync init --project bitly-devvm
```

