### PR TITLE
Add command to print current ip.

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -46,6 +46,18 @@ func List() *cobra.Command {
 	}
 }
 
+func GetCurrentIP() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get-ip",
+		Short: "Fetches your current public IP.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			currentIP, err := user.PublicIP()
+			fmt.Printf("current public IP: %s\n", currentIP)
+			return err
+		},
+	}
+}
+
 func prettyPrint(in []string) string {
 	builder := strings.Builder{}
 	for _, v := range in {

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ connecting from and keeps your development VM firewall rule up to date with that
 	rootCmd.AddCommand(cmd.Update())
 	rootCmd.AddCommand(cmd.List())
 	rootCmd.AddCommand(cmd.Sync())
+	rootCmd.AddCommand(cmd.GetCurrentIP())
 	rootCmd.AddCommand(versionCmd)
 
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
get-current-ip returns the current public IP address. Helpful for
debugging.
