### PR TITLE
bugfix: dumb logic error in Initialize

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -34,7 +34,7 @@ func Initialize() *cobra.Command {
 		Short: "Initialize fwsync configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if cloudProvider == config.ProviderGoogle {
+			if cloudProject == "" && cloudProvider == config.ProviderGoogle {
 				return fmt.Errorf("the provider: %s requires the --project argument", config.ProviderGoogle)
 			}
 


### PR DESCRIPTION
Fix a simple logic error that causes the Initialize function to error if
the cloudProvider is ever set to google.
