### PR TITLE
Supress duplicate errors.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,11 @@ jobs:
         with:
           go-version: '1.23'
 
+      - name: Install go-task
+        uses: go-task/setup-task@v1
+        with:
+          version: 3.x
+
       - name: Test
         run: go test -v ./...
 
@@ -28,6 +33,13 @@ jobs:
         with:
           go-version: '1.23'
 
+      - name: Install go-task
+        uses: go-task/setup-task@v1
+        with:
+          version: 3.x
+
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3.4.0
+        uses: golangci/golangci-lint-action@v9.2.0
+        with:
+          version: v2.7.0
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,28 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - gosimple
     - govet
     - ineffassign
+    - staticcheck
     - unused
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
     - goimports
-
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+tasks:
+  has:golangci-lint:
+    desc: Check if golangci-lint is installed
+    cmds:
+      - |
+        if ! command -v golangci-lint > /dev/null; then
+          echo "golangci-lint not found missing. To install see https://github.com/golangci/golangci-lint/releases"
+          exit 1
+        fi
+
+  lint:
+    desc: Run lint checks
+    deps:
+      - task: has:golangci-lint
+    cmds:
+      - golangci-lint run
+
+  test:
+    desc: Run test suites
+    cmds:
+      - go test -v ./...
+
+  build:
+    desc: Compile the project
+    cmds:
+      - go build -o ./bin/ -v ./...
+

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -30,8 +30,9 @@ func Initialize() *cobra.Command {
 	var ipLimit int
 
 	initCmd := &cobra.Command{
-		Use:   "init",
-		Short: "Initialize fwsync configuration.",
+		SilenceErrors: true, // errors are always propogated to main, no need to print again
+		Use:           "init",
+		Short:         "Initialize fwsync configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if cloudProject == "" && cloudProvider == config.ProviderGoogle {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -14,8 +14,9 @@ import (
 // List prints out the current source IPs configured in ~/.fwsync and the source IPs active on the GCP Firewall.
 func List() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
-		Short: "Display your firewall's allowed IPs.",
+		SilenceErrors: true, // errors are always propogated to main, no need to print again
+		Use:           "list",
+		Short:         "Display your firewall's allowed IPs.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// get local configured ips
 			home, _ := os.UserHomeDir()
@@ -60,8 +61,9 @@ func List() *cobra.Command {
 // This command will not update the fwsync configuration.
 func GetCurrentIP() *cobra.Command {
 	return &cobra.Command{
-		Use:   "get-ip",
-		Short: "Fetches your current public IP.",
+		SilenceErrors: true, // errors are always propogated to main, no need to print again
+		Use:           "get-ip",
+		Short:         "Fetches your current public IP.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			currentIP, err := config.PublicIP()
 			fmt.Printf("current public IP: %s\n", currentIP)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -19,8 +19,9 @@ func Update() *cobra.Command {
 	var skipSync bool
 
 	return &cobra.Command{
-		Use:   "update",
-		Short: "Allow a new IP on the firewall.",
+		SilenceErrors: true, // errors are always propogated to main, no need to print again
+		Use:           "update",
+		Short:         "Allow a new IP on the firewall.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// get local configuration
 			f, err := os.OpenFile(cfgFilePath, os.O_RDWR, 0666)
@@ -76,8 +77,9 @@ func Update() *cobra.Command {
 // Sync initiates a manual synchronization of the local configuration stored in ~/.fwsync to the desired GCP Firewall.
 func Sync() *cobra.Command {
 	return &cobra.Command{
-		Use:   "sync",
-		Short: "Synchronize local config with firewall",
+		SilenceErrors: true, // errors are always propogated to main, no need to print again
+		Use:           "sync",
+		Short:         "Synchronize local config with firewall",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// get local configuration
 			f, err := os.OpenFile(cfgFilePath, os.O_RDWR, 0666)

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 		Short: "A CLI utility to keep your development VM firewall up to date.",
 		Long: `fwsync uses a local file to keep track of the latest IP addresses you've been
 connecting from and keeps your development VM firewall rule up to date with that list.`,
+		SilenceUsage: true,
 	}
 
 	versionCmd := &cobra.Command{
@@ -41,13 +42,13 @@ connecting from and keeps your development VM firewall rule up to date with that
 	rootCmd.AddCommand(versionCmd)
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error running command: %q", err)
+		fmt.Fprintf(os.Stderr, "Error running command: %q\n", err)
 		os.Exit(1)
 	}
 
 	err := notifyIfUpdateAvailable()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error checking for updates: %q", err)
+		fmt.Fprintf(os.Stderr, "Error checking for updates: %q\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Duplicate errors result from returning error from a subcommand where the
root command also prints the error. This is weird behavior for Cobra but
it is supressed with a simple option.

This PR also adds a taskfile.
