### PR TITLE
Only check for available updates when running version cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Available Commands:
   list        Display your firewall's allowed IPs.
   sync        Synchronize local config with firewall
   update      Allow a new IP on the firewall.
-  version     Display version information
+  version     Display version information and check for updates.
 ```
 
 ## Supported Providers

--- a/main.go
+++ b/main.go
@@ -25,9 +25,12 @@ connecting from and keeps your development VM firewall rule up to date with that
 
 	versionCmd := &cobra.Command{
 		Use:   "version",
-		Short: "Display version information",
+		Short: "Display version information and check for updates",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println(version)
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			return notifyIfUpdateAvailable()
 		},
 	}
 
@@ -43,12 +46,6 @@ connecting from and keeps your development VM firewall rule up to date with that
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error running command: %q\n", err)
-		os.Exit(1)
-	}
-
-	err := notifyIfUpdateAvailable()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error checking for updates: %q\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Reduce the excess noise when a command is run by only checking for an
available update when the version command is run.
