### PR TITLE
bugfix: patch configuration on install.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,16 @@ wget -q $RELEASE
 tar -C $HOME/.local/bin/ --exclude README.md --exclude LICENSE -zxvf fwsync_${OS}_${ARCH}.tar.gz
 chmod +x $HOME/.local/bin/fwsync
 
+# patch existing configuration file for bitly users
+if [[ ! -z $HOME/.fwsync ]]; then
+  if ! grep 'provider' $HOME/.fwsync; then
+    cat << EOF > $HOME/.fwsync
+provider: google
+$(cat $HOME/.fwsync)
+EOF
+  fi
+fi
+
 rcfile="$HOME/.zshrc"
 if [[ $SHELL == "/bin/bash" ]]; then
   rcfile="$HOME/.bashrc"


### PR DESCRIPTION
When fwsync is upgraded on an existing install, the existing
configuration may not include a provider which is required as of v0.0.3.
This PR sets the provider to google for Bitly users who as of the
writing of this PR are the only consumers of this program.
