### PR TITLE
Add ldflags to build to set version.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,8 @@
 version: '3'
 
+vars:
+  VERSION: v0.0.0-devbuild
+
 tasks:
 
   has:golangci-lint:
@@ -26,5 +29,5 @@ tasks:
   build:
     desc: Compile the project
     cmds:
-      - go build -o ./bin/ -v ./...
+      - go build -o ./bin/ -ldflags="-X 'main.version={{.VERSION}}'" -v ./...
 


### PR DESCRIPTION
Add a VERSION variable to the Taskfile and ldflags to the go build
command to set the main.version variable. This is already done on
release, but for dev builds version ends up blank.
